### PR TITLE
Check zdotdir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,14 @@ git clone https://github.com/zap-zsh/zap.git "$HOME/.local/share/zap"
 
 mkdir "$HOME/.local/share/zap/plugins"
 
+# check if ZDOTDIR is set, and if it is, check if ZDOTDIR/.zshrc exists
+if [[ ! -z $ZDOTDIR ]] && [[ -f $ZDOTDIR/.zshrc ]]; then
+    zshrc="$ZDOTDIR/.zshrc"
+else
+    zshrc="$HOME/.zshrc"
+fi
+
 # shellcheck disable=SC2016
-if ! grep -q '[ -f "$HOME/.local/share/zap/zap.zsh" ] && source "$HOME/.local/share/zap/zap.zsh"' "$HOME/.zshrc"; then
-    echo '[ -f "$HOME/.local/share/zap/zap.zsh" ] && source "$HOME/.local/share/zap/zap.zsh"' >> "$HOME/.zshrc"
+if ! grep -q '[ -f "$HOME/.local/share/zap/zap.zsh" ] && source "$HOME/.local/share/zap/zap.zsh"' "$zshrc"; then
+    echo '[ -f "$HOME/.local/share/zap/zap.zsh" ] && source "$HOME/.local/share/zap/zap.zsh"' >> "$zshrc"
 fi


### PR DESCRIPTION
As of now, the install script assumes `.zshrc` lives at `$HOME/.zshrc`, which is a fairly reasonable assumption.

With that said, I think it's common for users to set `$ZDOTDIR` in their `$HOME/.zshenv` file so that all of the zsh config can be stored in a standard location like `$HOME/.config`. This PR just adds support for that use case. 

The additional check to make sure `$ZDOTDIR/.zshrc` exists seems redundant since the whole point of setting `$ZDOTDIR` is so that you can store `.zshrc` in there. I've added it *just in case* someone doesn't store their `.zshrc` in there. Please let me know if the check should be removed. 

I'd also be more than happy to add documentation for it if need be. 

As a final note, the usage of `$ZDOTDIR` is common among the zsh users that I know, but if it's a niche thing to do for the broader community and not a necessary check for this plugin, feel free to close the PR :)