### PR TITLE
fix: duplicated lines in `doc.txt`

### DIFF
--- a/doc.txt
+++ b/doc.txt
@@ -1,11 +1,9 @@
 zap [options]
 
 OPTIONS:
-    -h        help
-    --help    help
-    -v        version
-    --version version
-    update    update plugin(s)
-    delete    delete plugin(s)
-    pause     pause plugin(s)
-    unpause   unpause plugin(s)
+    -h, --help      help
+    -v, --version   version
+    update          update plugin(s)
+    delete          delete plugin(s)
+    pause           pause plugin(s)
+    unpause         unpause plugin(s)


### PR DESCRIPTION
short and long "flagged" options in the same line