### PR TITLE
feat: add "pin to commit" functionality

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -16,6 +16,9 @@ function zapplug() {
     if [ ! -d "$plugin_dir" ]; then
         echo "🔌$plugin_name"
         git clone "https://github.com/${full_plugin_name}.git" "$plugin_dir" > /dev/null 2>&1
+        if [[ ! -z $2 ]]; then                                              # check if the second arg of zapplug exist
+            cd $plugin_dir && git checkout "$2" > /dev/null 2>&1 && cd      # checkout the desidered commit
+        fi
         if [ $? -ne 0 ]; then
             echo "Failed to install $plugin_name"
             exit 1


### PR DESCRIPTION
wen calling `zapplug` if asecond arg is given it is used to checkout that particular commit

# Exxample
```sh
zapplug "zap-zsh/zap" f0f99ec6268adcf4e43766633621bad9d2cb1d0d
```