### PR TITLE
fix|update: Update, Pause, Unpause, Delete functions

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -37,17 +37,17 @@ plug() {
 }
 
 _pull() {
-        echo "🔌$1"
-        git pull > /dev/null 2>&1
-        if [ $? -ne 0 ]; then
-            echo "Failed to Update $1"
-            exit 1
-        fi
-        echo -e "\e[1A\e[K⚡$1"
+    echo "🔌$1"
+    git pull > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Failed to Update $1"
+        exit 1
+    fi
+    echo -e "\e[1A\e[K⚡$1"
 }
 
 update() {
-  plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
     echo -e " 0  ⚡ Zap"
     echo "$plugins \n"
     echo -n "🔌 Plugin Number | (a) All Plugins | (0) ⚡ Zap Itself: "
@@ -77,7 +77,7 @@ update() {
 }
 
 delete() {
-  plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
     echo "$plugins \n"
     echo -n "🔌 Plugin Number: "
     read plugin
@@ -85,7 +85,7 @@ delete() {
     for plug in $plugins; do
         usr=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5 }')
         plg=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $6 }')
-            sed -i "/$usr\/$plg/s/^/#/g" $ZAP_ZSHRC
+        sed -i "/$usr\/$plg/s/^/#/g" $ZAP_ZSHRC
         rm -rf $ZAP_PLUGIN_DIR/$plg && echo "Deleted $plg" || echo "Failed to Delete $plg"
     done
 }

--- a/zap.zsh
+++ b/zap.zsh
@@ -63,8 +63,7 @@ _pull() {
 update() {
     echo -e " 0  ⚡ Zap"
     plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
-    echo "$plugins"
-    echo ""
+    echo "$plugins \n"
     echo -n "🔌 Plugin Number | (a) All Plugins | (0) ⚡ Zap Itself: "
     read plugin
     pwd=$(pwd)
@@ -93,12 +92,10 @@ update() {
 
 delete() {
     plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
-    echo "$plugins"
-    echo ""
+    echo "$plugins \n"
     echo -n "🔌 Plugin Number: "
     read plugin
     pwd=$(pwd)
-    echo ""
     for plug in $plugins; do
         selected=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5"/"$6 }')
         rm -rf $ZAP_PLUGIN_DIR/$selected
@@ -106,26 +103,36 @@ delete() {
 }
 
 pause() {
-    ls -1 "$ZAP_PLUGIN_DIR"
-    echo ""
-    echo -n "Plugin Name or (a) to Update All: "
+    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E '^plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    echo "$plugins \n"
+    echo -n "🔌 Plugin Number: "
     read plugin
+    echo ""
     if [[ $plugin == "a" ]]; then
         sed -i '/^plug/s/^/#/g' $ZDOTDIR/.zshrc
     else
-        sed -i "/\/$plugin/s/^/#/g" $ZDOTDIR/.zshrc
+        for plug in $plugins; do
+            usr=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5 }')
+            plg=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $6 }')
+            sed -i "/$usr\/$plg/s/^/#/g" $ZDOTDIR/.zshrc
+        done
     fi
 }
 
 unpause() {
-    ls -1 "$ZAP_PLUGIN_DIR"
-    echo ""
-    echo -n "Plugin Name or (a) to Update All: "
+    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E '^#plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    echo "$plugins \n"
+    echo -n "🔌 Plugin Number | (a) Plug All: "
     read plugin
+    echo ""
     if [[ $plugin == "a" ]]; then
         sed -i '/^#plug/s/^#//g' $ZDOTDIR/.zshrc
     else
-        sed -i "/\/$plugin/s/^#//g" $ZDOTDIR/.zshrc
+        for plug in $plugins; do
+            usr=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5 }')
+            plg=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $6 }')
+            sed -i "/$usr\/$plg/s/^#//g" $ZDOTDIR/.zshrc
+        done
     fi
 }
 
@@ -137,7 +144,7 @@ version() {
     ref=$ZAP_DIR/.git/packed-refs
     tag=$(awk 'BEGIN { FS = "[ /]" } { print $3, $4 }' $ref | grep tags)
     ver=$(echo $tag | cut -d " " -f 2)
-    echo "⚡Zap Version v$ver"
+    echo "\n ⚡Zap Version v$ver \n"
 }
 
 zap() {

--- a/zap.zsh
+++ b/zap.zsh
@@ -59,14 +59,13 @@ update() {
     plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
     echo "$plugins"; echo ""; echo -n "🔌 Plugin Number | (a) All Plugins | (0) ⚡ Zap Itself: "; read plugin; pwd=$(pwd); echo "";
     if [[ $plugin == "a" ]]; then
-        cd "$ZAP_PLUGIN_DIR"
-        for plug in *; do
-            cd $plug; _pull $plug;
-        cd "$ZAP_PLUGIN_DIR"
-        done
+      cd "$ZAP_PLUGIN_DIR"
+      for plug in *; do
+        cd $plug; _pull $plug; cd "$ZAP_PLUGIN_DIR";
+      done
       cd $pwd > /dev/null 2>&1
-    elif [[ $plugin == " 0" ]]; then
-        cd "$ZAP_PLUGIN_DIR"; _pull 'zap'; cd $pwd
+    elif [[ $plugin == "0" ]]; then
+        cd "$ZAP_DIR"; _pull 'zap'; cd $pwd
     else
       for plug in $plugins; do
         selected=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5"/"$6 }'); cd "$ZAP_PLUGIN_DIR/$selected"; _pull $selected; cd - > /dev/null 2>&1

--- a/zap.zsh
+++ b/zap.zsh
@@ -60,9 +60,10 @@ _pull() {
     fi
 }
 
+plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+
 update() {
     echo -e " 0  ⚡ Zap"
-    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
     echo "$plugins \n"
     echo -n "🔌 Plugin Number | (a) All Plugins | (0) ⚡ Zap Itself: "
     read plugin
@@ -91,7 +92,6 @@ update() {
 }
 
 delete() {
-    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
     echo "$plugins \n"
     echo -n "🔌 Plugin Number: "
     read plugin

--- a/zap.zsh
+++ b/zap.zsh
@@ -74,8 +74,11 @@ update() {
 }
 
 delete() {
-    ls -1 "$ZAP_PLUGIN_DIR"; echo -n "Plugin Name: "; read plugin
-    cd "$ZAP_PLUGIN_DIR" && echo "Deleting $plugin ..." && rm -rf $plugin > /dev/null 2>&1 && cd - > /dev/null 2>&1 && echo "Deleted $plugin " || echo "Failed to delete : $plugin"
+    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    echo "$plugins"; echo ""; echo -n "🔌 Plugin Number: "; read plugin; pwd=$(pwd); echo "";
+    for plug in $plugins; do
+      selected=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5"/"$6 }'); rm -rf $ZAP_PLUGIN_DIR/$selected;
+    done
 }
 
 pause() {

--- a/zap.zsh
+++ b/zap.zsh
@@ -38,46 +38,70 @@ plug() {
 _pull() {
     _is_repo=$(ls .git > /dev/null 2>&1 && echo "T" || echo "F")
     if [[ $_is_repo == "T" ]]; then
-      echo "🔌$1"; git pull > /dev/null 2>&1
-      if [ $? -ne 0 ]; then
-          echo "Failed to Update $1"; exit 1
-      fi
-      echo -e "\e[1A\e[K⚡$1";
-    else
-      for plug in *; do
-        cd $plug; echo "🔌$plug"; git pull > /dev/null 2>&1;
+        echo "🔌$1"
+        git pull > /dev/null 2>&1
         if [ $? -ne 0 ]; then
-            echo "Failed to Update $plug"; exit 1
+            echo "Failed to Update $1"
+            exit 1
         fi
-        echo -e "\e[1A\e[K⚡$plug"; cd "$ZAP_PLUGIN_DIR/$1";
-      done
+        echo -e "\e[1A\e[K⚡$1"
+    else
+        for plug in *; do
+            cd $plug
+            echo "🔌$plug"
+            git pull > /dev/null 2>&1
+            if [ $? -ne 0 ]; then
+                echo "Failed to Update $plug"
+                exit 1
+            fi
+            echo -e "\e[1A\e[K⚡$plug"
+            cd "$ZAP_PLUGIN_DIR/$1"
+        done
     fi
 }
 
 update() {
     echo -e " 0  ⚡ Zap"
     plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
-    echo "$plugins"; echo ""; echo -n "🔌 Plugin Number | (a) All Plugins | (0) ⚡ Zap Itself: "; read plugin; pwd=$(pwd); echo "";
+    echo "$plugins"
+    echo ""
+    echo -n "🔌 Plugin Number | (a) All Plugins | (0) ⚡ Zap Itself: "
+    read plugin
+    pwd=$(pwd)
+    echo ""
     if [[ $plugin == "a" ]]; then
-      cd "$ZAP_PLUGIN_DIR"
-      for plug in *; do
-        cd $plug; _pull $plug; cd "$ZAP_PLUGIN_DIR";
-      done
-      cd $pwd > /dev/null 2>&1
+        cd "$ZAP_PLUGIN_DIR"
+        for plug in *; do
+            cd $plug
+            _pull $plug
+            cd "$ZAP_PLUGIN_DIR"
+        done
+        cd $pwd > /dev/null 2>&1
     elif [[ $plugin == "0" ]]; then
-        cd "$ZAP_DIR"; _pull 'zap'; cd $pwd
+        cd "$ZAP_DIR"
+        _pull 'zap'
+        cd $pwd
     else
-      for plug in $plugins; do
-        selected=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5"/"$6 }'); cd "$ZAP_PLUGIN_DIR/$selected"; _pull $selected; cd - > /dev/null 2>&1
-      done
+        for plug in $plugins; do
+            selected=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5"/"$6 }')
+            cd "$ZAP_PLUGIN_DIR/$selected"
+            _pull $selected
+            cd - > /dev/null 2>&1
+        done
     fi
 }
 
 delete() {
     plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZDOTDIR/.zshrc | grep -E 'plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
-    echo "$plugins"; echo ""; echo -n "🔌 Plugin Number: "; read plugin; pwd=$(pwd); echo "";
+    echo "$plugins"
+    echo ""
+    echo -n "🔌 Plugin Number: "
+    read plugin
+    pwd=$(pwd)
+    echo ""
     for plug in $plugins; do
-      selected=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5"/"$6 }'); rm -rf $ZAP_PLUGIN_DIR/$selected;
+        selected=$(echo $plug | grep $plugin | awk 'BEGIN { FS = "[ /]" } { print $5"/"$6 }')
+        rm -rf $ZAP_PLUGIN_DIR/$selected
     done
 }
 
@@ -105,11 +129,11 @@ unpause() {
     fi
 }
 
-Help() {
+help() {
     cat "$ZAP_DIR/doc.txt"
 }
 
-Version() {
+version() {
     ref=$ZAP_DIR/.git/packed-refs
     tag=$(awk 'BEGIN { FS = "[ /]" } { print $3, $4 }' $ref | grep tags)
     ver=$(echo $tag | cut -d " " -f 2)
@@ -119,11 +143,11 @@ Version() {
 zap() {
     local command="$1"
     if [[ $command == "-v" ]] || [[ $command == "--version" ]]; then
-        Version
+        version
         return
     else
         if [[ $command == "-h" ]] || [[ $command == "--help" ]]; then
-            Help
+            help
             return
         else
             $command

--- a/zap.zsh
+++ b/zap.zsh
@@ -93,7 +93,7 @@ delete() {
 pause() {
     plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
     echo "$plugins \n"
-    echo -n "🔌 Plugin Number: "
+    echo -n "🔌 Plugin Number | (a) All Plugins: "
     read plugin
     echo ""
     if [[ $plugin == "a" ]]; then


### PR DESCRIPTION
Fixing issue #35 and now instead of typing the entire plugin name one can just type a letter [a], or a number [0,1,2 ...] to prevent the frustration of ty[os

![Picture_7](https://user-images.githubusercontent.com/93865776/201471712-bb10b7ef-1d18-4c75-8c7e-fbc9b29f7b35.png)
