### PR TITLE
Feat/don't ask unneeded input on (de)activate

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -94,7 +94,7 @@ _zap_remove() {
     for plug in $plugins; do
         usr=$(echo $plug | grep -E "^ $plugin" | awk 'BEGIN { FS = "[ /]" } { print $5 }')
         plg=$(echo $plug | grep -E "^ $plugin" | awk 'BEGIN { FS = "[ /]" } { print $6 }')
-        sed -i'.backup' "/$usr\/$plg/s/^/#\ /g" $ZAP_ZSHRC
+        sed -i'.backup' --follow-symlinks "/$usr\/$plg/s/^/#\ /g" $ZAP_ZSHRC
         rm -rf $ZAP_PLUGIN_DIR/$plg && echo "Removed $usr's $plg plugin" || echo "Failed to Remove $usr's $plg plugin \n"
     done
 }
@@ -110,12 +110,12 @@ _zap_deactivate() {
     read plugin
     echo ""
     if [[ $plugin == "a" ]]; then
-        sed -i'.backup' '/^plug/s/^/#\ /g' $ZAP_ZSHRC && echo "Deactivated all active plugins" || echo "Failed to Deactivate all active plugins \n"
+        sed -i'.backup' --follow-symlinks '/^plug/s/^/#\ /g' $ZAP_ZSHRC && echo "Deactivated all active plugins" || echo "Failed to Deactivate all active plugins \n"
     else
         for plug in $plugins; do
             usr=$(echo $plug | grep -E "^ $plugin" | awk 'BEGIN { FS = "[ /]" } { print $5 }')
             plg=$(echo $plug | grep -E "^ $plugin" | awk 'BEGIN { FS = "[ /]" } { print $6 }')
-            sed -i'.backup' "/$usr\/$plg/s/^/#\ /g" $ZAP_ZSHRC && echo "Deactivated $usr's $plg plugin" || echo "Failed to Deactivate $usr's $plg plugin \n"
+            sed -i'.backup' --follow-symlinks "/$usr\/$plg/s/^/#\ /g" $ZAP_ZSHRC && echo "Deactivated $usr's $plg plugin" || echo "Failed to Deactivate $usr's $plg plugin \n"
         done
     fi
 }
@@ -131,12 +131,12 @@ _zap_activate() {
     read plugin
     echo ""
     if [[ $plugin == "a" ]]; then
-        sed -i'.backup' '/^#\ plug/s/^#\ //g' $ZAP_ZSHRC && echo "Activated all inactive plugins" || echo "Failed to Activate all inactive plugins \n"
+        sed -i'.backup' --follow-symlinks '/^#\ plug/s/^#\ //g' $ZAP_ZSHRC && echo "Activated all inactive plugins" || echo "Failed to Activate all inactive plugins \n"
     else
         for plug in $plugins; do
             usr=$(echo $plug | grep -E "^ $plugin" | awk 'BEGIN { FS = "[ /]" } { print $5 }')
             plg=$(echo $plug | grep -E "^ $plugin" | awk 'BEGIN { FS = "[ /]" } { print $6 }')
-            sed -i'.backup' "/$usr\/$plg/s/^#\ //g" $ZAP_ZSHRC && echo "Activated $usr's $plg plugin" || echo "Failed to Activate $usr's $plg plugin \n"
+            sed -i'.backup' --follow-symlinks "/$usr\/$plg/s/^#\ //g" $ZAP_ZSHRC && echo "Activated $usr's $plg plugin" || echo "Failed to Activate $usr's $plg plugin \n"
         done
     fi
 }

--- a/zap.zsh
+++ b/zap.zsh
@@ -83,6 +83,10 @@ _zap_update() {
 
 _zap_remove() {
     plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    if [ -z $plugins ]; then
+        echo "There are no plugins"
+        return 0
+    fi
     echo "$plugins \n"
     echo -n "🔌 Plugin Number: "
     read plugin
@@ -97,6 +101,10 @@ _zap_remove() {
 
 _zap_deactivate() {
     plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    if [ -z $plugins ]; then
+        echo "There is no plugin to deactivate"
+        return 0
+    fi
     echo "$plugins \n"
     echo -n "🔌 Plugin Number | (a) All Plugins: "
     read plugin
@@ -114,6 +122,10 @@ _zap_deactivate() {
 
 _zap_activate() {
     plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^# plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $4 }')
+    if [ -z $plugins ]; then
+        echo "All plugins are active"
+        return 0
+    fi
     echo "$plugins \n"
     echo -n "🔌 Plugin Number | (a) Plug All: "
     read plugin


### PR DESCRIPTION
I've also added `--follow-symlinks` to the `sed` commands.

A lot of people use dotfile repos and create symlinks. I think it makes more sense to have the original changed than to break the link (the backup is still created).

I was making changes to my `.zshrc` in my repo and nothing was being picked up as the link broke, it was quite confusing .