### PR TITLE
feat: plugins will be cleaned up after update, removed activate, deactivate, remove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 plugins/
+installed_plugins

--- a/doc.txt
+++ b/doc.txt
@@ -4,6 +4,4 @@ OPTIONS:
     -h, --help        help
     -v, --version     version
     -u, --update      update plugin(s)
-    -a, --activate    activate plugin(s)
-    -d, --deactivate  deactivate plugin(s)
-    -r, --remove      remove plugin(s)
+    -c, --clean       clean plugin(s)

--- a/zap.zsh
+++ b/zap.zsh
@@ -48,7 +48,7 @@ _pull() {
 }
 
 _zap_update() {
-    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^plug "[Aa0-Zz9]' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
     echo -e " 0  ⚡ Zap"
     echo "$plugins \n"
     echo -n "🔌 Plugin Number | (a) All Plugins | (0) ⚡ Zap Itself: "
@@ -78,7 +78,7 @@ _zap_update() {
 }
 
 _zap_remove() {
-    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^plug "[Aa0-Zz9]' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
     echo "$plugins \n"
     echo -n "🔌 Plugin Number: "
     read plugin
@@ -92,7 +92,7 @@ _zap_remove() {
 }
 
 _zap_deactivate() {
-    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
+    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^plug "[Aa0-Zz9]' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $3 }')
     echo "$plugins \n"
     echo -n "🔌 Plugin Number | (a) All Plugins: "
     read plugin
@@ -109,7 +109,7 @@ _zap_deactivate() {
 }
 
 _zap_activate() {
-    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^# plug "' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $4 }')
+    plugins=$(awk 'BEGIN { FS = "[ plug]" } { print }' $ZAP_ZSHRC | grep -E '^# plug "[Aa0-Zz9]' | awk 'BEGIN { FS = "[ \"]" } { print " " int((NR)) echo "  🔌 " $4 }')
     echo "$plugins \n"
     echo -n "🔌 Plugin Number | (a) Plug All: "
     read plugin

--- a/zap.zsh
+++ b/zap.zsh
@@ -55,12 +55,8 @@ _zap_clean() {
     unused_plugins=()
     for i in "$HOME"/.local/share/zap/plugins/*; do
         local plugin_name=$(basename "$i")
-        # echo "plugin name: $plugin_name"
-        # echo "i: $i"
         if ! grep -q "$plugin_name" "$HOME/.local/share/zap/installed_plugins"; then
             unused_plugins+=("$plugin_name")
-            # the next line is commented out.  Test it.  Then uncomment to removed the files
-            # rm "$i"
         fi
     done
     for p in ${unused_plugins[@]}; do

--- a/zap.zsh
+++ b/zap.zsh
@@ -39,8 +39,7 @@ plug() {
         _try_source "$plugin_dir/$plugin_name.zsh"
         _try_source "$plugin_dir/$plugin_name.zsh-theme"
     fi
-    # append active plugin
-    if [[ -n "$full_plugin_name" ]]; then
+    if [[ -n $full_plugin_name ]]; then
         echo "$full_plugin_name" >> "$HOME/.local/share/zap/installed_plugins"
     fi
 }
@@ -135,4 +134,3 @@ zap() {
 }
 
 # vim: ft=bash ts=4 et
-

--- a/zap.zsh
+++ b/zap.zsh
@@ -51,6 +51,28 @@ _pull() {
     echo -e "\e[1A\e[K⚡$1"
 }
 
+_zap_clean() {
+    unused_plugins=()
+    for i in "$HOME"/.local/share/zap/plugins/*; do
+        local plugin_name=$(basename "$i")
+        # echo "plugin name: $plugin_name"
+        # echo "i: $i"
+        if ! grep -q "$plugin_name" "$HOME/.local/share/zap/installed_plugins"; then
+            unused_plugins+=("$plugin_name")
+            # the next line is commented out.  Test it.  Then uncomment to removed the files
+            # rm "$i"
+        fi
+    done
+    for p in ${unused_plugins[@]}; do
+        echo -n "Remove: $p? (y/n): "
+        read answer
+        if [[ $answer == "y" ]]; then
+            rm -rf "$HOME/.local/share/zap/plugins/$p"
+            echo "removed: $p"
+        fi
+    done
+}
+
 _zap_update() {
     plugins=$(cat "$HOME/.local/share/zap/installed_plugins" | awk 'BEGIN { FS = "\n" } { print " " int((NR)) echo "  🔌 " $1 }')
     echo -e " 0  ⚡ Zap"
@@ -79,27 +101,9 @@ _zap_update() {
             cd - > /dev/null 2>&1
         done
     fi
-
-    unused_plugins=()
-    for i in "$HOME"/.local/share/zap/plugins/*; do
-        local plugin_name=$(basename "$i")
-        # echo "plugin name: $plugin_name"
-        # echo "i: $i"
-        if ! grep -q "$plugin_name" "$HOME/.local/share/zap/installed_plugins"; then
-            unused_plugins+=("$plugin_name")
-            # the next line is commented out.  Test it.  Then uncomment to removed the files
-            # rm "$i"
-        fi
-
-    done
-    for p in ${unused_plugins[@]}; do
-        echo -n "Remove: $p? (y/n): "
-        read answer
-        if [[ $answer == "y" ]]; then
-            rm -rf "$HOME/.local/share/zap/plugins/$p"
-            echo "removed: $p"
-        fi
-    done
+    if [[ $ZAP_CLEAN_ON_UPDATE == true ]]; then
+        _zap_clean
+    fi
 }
 
 _zap_help() {
@@ -119,6 +123,8 @@ opts=(
     --help "_zap_help"
     -u "_zap_update"
     --update "_zap_update"
+    -c "_zap_clean"
+    --clean "_zap_clean"
     -v "_zap_version"
     --version "_zap_version"
 )
@@ -134,3 +140,4 @@ zap() {
 }
 
 # vim: ft=bash ts=4 et
+

--- a/zap.zsh
+++ b/zap.zsh
@@ -140,4 +140,3 @@ zap() {
 }
 
 # vim: ft=bash ts=4 et
-


### PR DESCRIPTION
The regex to support activate and deactivate was getting a little complicated

deactivating a plugin can be done by commenting it out, activating by removing the comment

zap will ask the user after updating if they would like to remove plugins no longer in their config