### PR TITLE
feat: check if plugin needs to be updated

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -84,7 +84,7 @@ _zap_update() {
             state=$(echo -e "       ... up to date")
             echo -e "\e[32m${state}\e[0m"
         elif [ $LOCAL = $BASE ]; then
-            state=$(echo -e "      ... new changes found, update. \n")
+            state=$(echo -e "      ... new version available, update.")
             echo -e "\e[31m${state}\e[0m"
         fi
         cd "$ZAP_PLUGIN_DIR"
@@ -108,11 +108,11 @@ _zap_update() {
         for plug in *; do
             cd $plug
             _pull $plug
+            cd "$ZAP_PLUGIN_DIR"
         done
     elif [[ $plugin == "0" ]]; then
         cd "$ZAP_DIR"
         _pull 'zap'
-        cd "$ZAP_PLUGIN_DIR"
     else
         cd "$ZAP_PLUGIN_DIR"
         selected=$(echo $plugins | grep -E "^ $plugin" | awk 'BEGIN { FS = "[ /]" } { print $5 }')

--- a/zap.zsh
+++ b/zap.zsh
@@ -48,7 +48,7 @@ plug() {
 _pull() {
     echo "🔌 $1"
     git pull > /dev/null 2>&1
-    # if [ $? -ne 0 ]; then echo "Failed to update $1" && exit 1; fi
+    if [ $? -ne 0 ]; then echo "Failed to update $1" && exit 1; fi
     echo -e "\e[1A\e[K⚡ $1"
 }
 
@@ -84,6 +84,7 @@ _zap_update() {
         fi
         cd "$ZAP_PLUGIN_DIR"
     }
+    # plugins=$(cat "$HOME/.local/share/zap/installed_plugins" | awk 'BEGIN { FS = "\n" } { print " " int((NR)) echo "  🔌 " $1 }')
     plugins=$(ls "$HOME/.local/share/zap/plugins" | awk 'BEGIN { FS = "\n" } { print " " int((NR)) echo "  🔌 " $1 }')
     pwd=$(pwd)
     cd "$ZAP_DIR"
@@ -103,6 +104,7 @@ _zap_update() {
         for plug in *; do
             cd $plug
             _pull $plug
+            cd "$ZAP_PLUGIN_DIR"
         done
     elif [[ $plugin == "0" ]]; then
         cd "$ZAP_DIR"

--- a/zap.zsh
+++ b/zap.zsh
@@ -80,22 +80,24 @@ _zap_update() {
         LOCAL=$(git rev-parse @)
         REMOTE=$(git rev-parse "$UPSTREAM")
         BASE=$(git merge-base @ "$UPSTREAM")
-
         if [ $LOCAL = $REMOTE ]; then
-            echo -e "... up to date"
+            state=$(echo -e "       ... up to date")
+            echo -e "\e[32m${state}\e[0m"
         elif [ $LOCAL = $BASE ]; then
-            echo -e "... new changes found, update."
+            state=$(echo -e "      ... new changes found, update. \n")
+            echo -e "\e[31m${state}\e[0m"
         fi
         cd "$ZAP_PLUGIN_DIR"
     }
     plugins=$(ls "$HOME/.local/share/zap/plugins" | awk 'BEGIN { FS = "\n" } { print " " int((NR)) echo "  🔌 " $1 }')
     pwd=$(pwd)
     cd "$ZAP_DIR"
-    echo " 0  ⚡ Zap" | grep -E "Zap"
+    echo " 0  ⚡ Zap"
     _changes
     for plug in *; do
         cd $plug
-        echo -n $plugins | grep "$plug$"
+        show=$(echo -n $plugins | grep "$plug$")
+        echo -e "$show"
         _changes
     done
     echo -n "🔌 Plugin Number | (a) All Plugins | (0) ⚡ Zap Itself: "
@@ -110,6 +112,7 @@ _zap_update() {
     elif [[ $plugin == "0" ]]; then
         cd "$ZAP_DIR"
         _pull 'zap'
+        cd "$ZAP_PLUGIN_DIR"
     else
         cd "$ZAP_PLUGIN_DIR"
         selected=$(echo $plugins | grep -E "^ $plugin" | awk 'BEGIN { FS = "[ /]" } { print $5 }')

--- a/zap.zsh
+++ b/zap.zsh
@@ -76,20 +76,22 @@ _zap_clean() {
 
 _zap_update() {
     _changes() {
-        count=$(git remote update > /dev/null 2>&1 && git status -uno | grep "modified" | wc -l)
-        mods=$(git remote update > /dev/null 2>&1 && git status -uno | grep "modified" | head -5)
-        if [[ $count -ne 0 ]]; then
-            echo -e "   $mods"
-            echo -e "   ... $count new change(s), update. \n"
+        UPSTREAM=${1:-'@{u}'}
+        LOCAL=$(git rev-parse @)
+        REMOTE=$(git rev-parse "$UPSTREAM")
+        BASE=$(git merge-base @ "$UPSTREAM")
+
+        if [ $LOCAL = $REMOTE ]; then
+            echo -e "... up to date"
+        elif [ $LOCAL = $BASE ]; then
+            echo -e "... new changes found, update."
         fi
         cd "$ZAP_PLUGIN_DIR"
     }
-    # plugins=$(cat "$HOME/.local/share/zap/installed_plugins" | awk 'BEGIN { FS = "\n" } { print " " int((NR)) echo "  🔌 " $1 }')
     plugins=$(ls "$HOME/.local/share/zap/plugins" | awk 'BEGIN { FS = "\n" } { print " " int((NR)) echo "  🔌 " $1 }')
     pwd=$(pwd)
     cd "$ZAP_DIR"
     echo " 0  ⚡ Zap" | grep -E "Zap"
-    git remote update > /dev/null 2>&1 && git status -uno | grep "modified" > /dev/null 2>&1
     _changes
     for plug in *; do
         cd $plug
@@ -104,7 +106,6 @@ _zap_update() {
         for plug in *; do
             cd $plug
             _pull $plug
-            cd "$ZAP_PLUGIN_DIR"
         done
     elif [[ $plugin == "0" ]]; then
         cd "$ZAP_DIR"

--- a/zap.zsh
+++ b/zap.zsh
@@ -130,10 +130,8 @@ _zap_help() {
 }
 
 _zap_version() {
-    ref=$ZAP_DIR/.git/packed-refs
-    tag=$(awk 'BEGIN { FS = "[ /]" } { print $3, $4 }' $ref | grep tags | tail -1)
-    ver=$(echo $tag | cut -d " " -f 2)
-    echo "⚡Zap Version v$ver"
+    release=$(gh release list --repo https://github.com/zap-zsh/zap | grep -E "Latest")
+    echo "⚡$release"
 }
 
 typeset -A opts


### PR DESCRIPTION
When using the `installed_plugins` list it jumbles up the order of plugins like 3,1,6,4 ... Using `ls` orders well. The list order should be alphabetical.
issue: #59

![Picture_11](https://user-images.githubusercontent.com/93865776/201783374-fb485937-4e77-4d4a-ab7c-8373b605755e.png)
