### PR TITLE
feat: modify _try_source and ZOTDIR with .zshrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ main() {
     mkdir -p "$HOME/.local/share/zap/plugins"
 
     # check if ZDOTDIR is set, and if it is, check if ZDOTDIR/.zshrc exists
-    if [ -n "$ZDOTDIR" ] && [ -f "$ZDOTDIR/.zshrc" ]; then
+    if [ -n "$ZDOTDIR" ]; then
         zshrc="$ZDOTDIR/.zshrc"
     else
         zshrc="$HOME/.zshrc"

--- a/install.sh
+++ b/install.sh
@@ -5,11 +5,7 @@ main() {
     mkdir -p "$HOME/.local/share/zap/plugins"
 
     # check if ZDOTDIR is set, and if it is, check if ZDOTDIR/.zshrc exists
-    if [ -n "$ZDOTDIR" ]; then
-        zshrc="$ZDOTDIR/.zshrc"
-    else
-        zshrc="$HOME/.zshrc"
-    fi
+    zshrc="${ZDOTDIR:-$HOME}/.zshrc"
     touch "$zshrc"
 
     # shellcheck disable=SC2016

--- a/zap.zsh
+++ b/zap.zsh
@@ -12,8 +12,18 @@ else
 fi
 
 _try_source() {
-    # shellcheck disable=SC1090
-    [ -f "$1" ] && source "$1"
+  sourced=false
+  local plugin_dir="$1"
+  local plugin_name="$2"
+  plugin_files=("$plugin_dir/$plugin_name.plugin.zsh" "$plugin_dir/$plugin_name.zsh" "$plugin_dir/$plugin_name.zsh-theme" "$plugin_dir/${plugin_name#zsh-}.zsh")
+  for i in "${plugin_files[@]}"
+  do
+    if [ -e "$i" ]; then
+        source "$i"
+        sourced=true
+        break
+    fi
+  done
 }
 
 plug() {
@@ -36,9 +46,10 @@ plug() {
             fi
             echo -e "\e[1A\e[K⚡$plugin_name"
         fi
-        _try_source "$plugin_dir/$plugin_name.plugin.zsh"
-        _try_source "$plugin_dir/$plugin_name.zsh"
-        _try_source "$plugin_dir/$plugin_name.zsh-theme"
+        _try_source $plugin_dir $plugin_name
+        if [[ $sourced == false ]]; then
+          echo "Failed to soruce $full_plugin_name"
+        fi
     fi
     if [[ -n $full_plugin_name ]]; then
         echo "$full_plugin_name" >> "$HOME/.local/share/zap/installed_plugins"

--- a/zap.zsh
+++ b/zap.zsh
@@ -12,18 +12,17 @@ else
 fi
 
 _try_source() {
-  sourced=false
-  local plugin_dir="$1"
-  local plugin_name="$2"
-  plugin_files=("$plugin_dir/$plugin_name.plugin.zsh" "$plugin_dir/$plugin_name.zsh" "$plugin_dir/$plugin_name.zsh-theme" "$plugin_dir/${plugin_name#zsh-}.zsh")
-  for i in "${plugin_files[@]}"
-  do
-    if [ -e "$i" ]; then
-        source "$i"
-        sourced=true
-        break
-    fi
-  done
+    sourced=false
+    local plugin_dir="$1"
+    local plugin_name="$2"
+    plugin_files=("$plugin_dir/$plugin_name.plugin.zsh" "$plugin_dir/$plugin_name.zsh" "$plugin_dir/$plugin_name.zsh-theme" "$plugin_dir/${plugin_name#zsh-}.zsh")
+    for i in "${plugin_files[@]}"; do
+        if [ -e "$i" ]; then
+            source "$i"
+            sourced=true
+            break
+        fi
+    done
 }
 
 plug() {
@@ -48,7 +47,7 @@ plug() {
         fi
         _try_source $plugin_dir $plugin_name
         if [[ $sourced == false ]]; then
-          echo "Failed to soruce $full_plugin_name"
+            echo "Failed to soruce $full_plugin_name"
         fi
     fi
     if [[ -n $full_plugin_name ]]; then

--- a/zap.zsh
+++ b/zap.zsh
@@ -5,11 +5,7 @@ fpath=(~/.local/share/zap/completion $fpath)
 rm -rf "$HOME/.local/share/zap/installed_plugins"
 export ZAP_DIR="$HOME/.local/share/zap"
 export ZAP_PLUGIN_DIR="$ZAP_DIR/plugins"
-if [ -z "$ZDOTDIR" ]; then
-    export ZAP_ZSHRC="$HOME/.zshrc" # ~/.zshrc
-else
-    export ZAP_ZSHRC="$ZDOTDIR/.zshrc"
-fi
+export ZAP_ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
 
 _try_source() {
     sourced=false

--- a/zap.zsh
+++ b/zap.zsh
@@ -15,8 +15,11 @@ _try_source() {
     sourced=false
     local plugin_dir="$1"
     local plugin_name="$2"
-    plugin_files=("$plugin_dir/$plugin_name.plugin.zsh" "$plugin_dir/$plugin_name.zsh" "$plugin_dir/$plugin_name.zsh-theme" "$plugin_dir/${plugin_name#zsh-}.zsh")
-    for i in "${plugin_files[@]}"; do
+    plugin_files_names=("$plugin_dir/$plugin_name.plugin.zsh"
+        "$plugin_dir/$plugin_name.zsh"
+        "$plugin_dir/$plugin_name.zsh-theme"
+        "$plugin_dir/${plugin_name#zsh-}.zsh")
+    for i in "${plugin_files_names[@]}"; do
         if [ -e "$i" ]; then
             source "$i"
             sourced=true

--- a/zap.zsh
+++ b/zap.zsh
@@ -13,9 +13,7 @@ fi
 
 _try_source() {
     sourced=false
-    local plugin_dir="$1"
-    local plugin_name="$2"
-    plugin_files_names=("$plugin_dir/$plugin_name.plugin.zsh"
+    plugin_files_names=("$1/$2.plugin.zsh"
         "$plugin_dir/$plugin_name.zsh"
         "$plugin_dir/$plugin_name.zsh-theme"
         "$plugin_dir/${plugin_name#zsh-}.zsh")


### PR DESCRIPTION
Added support for plugins with name `zsh-<plugin>/<plugin>.zsh` for plugins like `"Tarrasch/zsh-autoenv"`.
Removed the check for `.zshrc` when `$ZDOTDIR` is set, since the default becomes $HOME. 
