### PR TITLE
Add sub_plug command

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -24,24 +24,55 @@ plug() {
         local full_plugin_name="$1"
         local git_ref="$2"
         local plugin_name=$(echo "$full_plugin_name" | cut -d "/" -f 2)
-        local plugin_dir="$ZAP_PLUGIN_DIR/$plugin_name"
-        if [ ! -d "$plugin_dir" ]; then
+        local plugin_install_dir="$ZAP_PLUGIN_DIR/$plugin_name"
+        if [ ! -d "$plugin_install_dir" ]; then
             echo "🔌$plugin_name"
-            git clone "https://github.com/${full_plugin_name}.git" --depth 1 "$plugin_dir" > /dev/null 2>&1
+            git clone "https://github.com/${full_plugin_name}.git" --depth 1 "$plugin_install_dir" > /dev/null 2>&1
             if [ $? -ne 0 ]; then echo "Failed to clone $plugin_name" && return 1; fi
 
             if [ -n "$git_ref" ]; then
-                git -C "$plugin_dir" checkout "$git_ref" > /dev/null 2>&1
+                git -C "$plugin_install_dir" checkout "$git_ref" > /dev/null 2>&1
                 if [ $? -ne 0 ]; then echo "Failed to checkout $git_ref" && return 1; fi
             fi
             echo -e "\e[1A\e[K⚡$plugin_name"
         fi
-        _try_source "$plugin_dir/$plugin_name.plugin.zsh"
-        _try_source "$plugin_dir/$plugin_name.zsh"
-        _try_source "$plugin_dir/$plugin_name.zsh-theme"
+        _try_source "$plugin_install_dir/$plugin_name.plugin.zsh"
+        _try_source "$plugin_install_dir/$plugin_name.zsh"
+        _try_source "$plugin_install_dir/$plugin_name.zsh-theme"
     fi
     if [[ -n $full_plugin_name ]]; then
         echo "$full_plugin_name" >> "$HOME/.local/share/zap/installed_plugins"
+    fi
+}
+
+sub_plug() {
+    local full_plugin_name="$1"
+    local git_ref="$2"
+    local plugin_sub_name="$3"
+    local plugin_sub_path="$4"
+
+    # Path equals name if not given.
+    [ -z "$plugin_sub_path" ] && plugin_sub_path="$plugin_sub_path"
+
+    local plugin_name=$(echo "$full_plugin_name" | cut -d "/" -f 2)
+    local plugin_install_dir="$ZAP_PLUGIN_DIR/$plugin_name"
+
+    if [ ! -d "$plugin_install_dir" ]; then
+        echo "🔌[$plugin_name] $plugin_sub_name"
+        git clone "https://github.com/${full_plugin_name}.git" --depth 1 "$plugin_install_dir" > /dev/null 2>&1
+        if [ $? -ne 0 ]; then echo "Failed to clone $plugin_name" && return 1; fi
+
+        if [ -n "$git_ref" ]; then
+            git -C "$plugin_install_dir" checkout "$git_ref" > /dev/null 2>&1
+            if [ $? -ne 0 ]; then echo "Failed to checkout $git_ref" && return 1; fi
+        fi
+        echo -e "\e[1A\e[K⚡[$plugin_name] $plugin_sub_name"
+    fi
+    _try_source "$plugin_install_dir/$plugin_sub_path/$plugin_sub_name.plugin.zsh"
+    _try_source "$plugin_install_dir/$plugin_sub_path/$plugin_sub_name.zsh"
+    _try_source "$plugin_install_dir/$plugin_sub_path/$plugin_sub_name.zsh-theme"
+    if [[ -n $full_plugin_name ]]; then
+        echo "$full_plugin_name [$plugin_sub_name]" >> "$HOME/.local/share/zap/installed_plugins"
     fi
 }
 

--- a/zap.zsh
+++ b/zap.zsh
@@ -17,7 +17,7 @@ _try_source() {
 }
 
 plug() {
-    plugin="$1"
+    local plugin="$1"
     if [ -f "$plugin" ]; then
         source "$plugin"
     else
@@ -53,7 +53,7 @@ _pull() {
 }
 
 _zap_clean() {
-    unused_plugins=()
+    local unused_plugins=()
     for i in "$HOME"/.local/share/zap/plugins/*; do
         local plugin_name=$(basename "$i")
         if ! grep -q "$plugin_name" "$HOME/.local/share/zap/installed_plugins"; then
@@ -75,12 +75,12 @@ _zap_clean() {
 }
 
 _zap_update() {
-    plugins=$(cat "$HOME/.local/share/zap/installed_plugins" | awk 'BEGIN { FS = "\n" } { print " " int((NR)) echo "  🔌 " $1 }')
+    local plugins=$(cat "$HOME/.local/share/zap/installed_plugins" | awk 'BEGIN { FS = "\n" } { print " " int((NR)) echo "  🔌 " $1 }')
     echo -e " 0  ⚡ Zap"
     echo "$plugins \n"
     echo -n "🔌 Plugin Number | (a) All Plugins | (0) ⚡ Zap Itself: "
     read plugin
-    pwd=$(pwd)
+    local pwd=$(pwd)
     echo ""
     if [[ $plugin == "a" ]]; then
         cd "$ZAP_PLUGIN_DIR"


### PR DESCRIPTION
`sub_plug` can be used to install plugins that don't necessarily:

* have the name of the repository.
* are in the root of the repository.

This doesn't change the way `plug` works. Multiple plugins that are part
of the same repository will not be installed several times. A single
directory is instead used to hold these plugins. Update and clean work
the same way, although --clean will only remove a directory if **all**
of its plugins are missing from `.zshrc`.

Minor refactor: `plugin_dir` → `plugin_install_dir`, to avoid confusion
in `sub_plug`.