### PR TITLE
Source zap at the beginning of the zshrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,8 @@ main() {
 
     # shellcheck disable=SC2016
     if ! grep -q '[ -f "$HOME/.local/share/zap/zap.zsh" ] && source "$HOME/.local/share/zap/zap.zsh"' "$zshrc"; then
-        echo '[ -f "$HOME/.local/share/zap/zap.zsh" ] && source "$HOME/.local/share/zap/zap.zsh"' >> "$zshrc"
+        sed -i '1 i\
+[ -f "$HOME/.local/share/zap/zap.zsh" ] && source "$HOME/.local/share/zap/zap.zsh"' "$zshrc"
     fi
 }
 


### PR DESCRIPTION
It avoids that beginners zsh, or maybe shell, users have to think about where to put that line in their zshrc.