### PR TITLE
Fix: install.sh sh->zsh shebang to guarantee read .zshenv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env zsh
 
 main() {
     branch="master"

--- a/zap.zsh
+++ b/zap.zsh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env zsh
 # shellcheck disable=SC1090
 
 export ZAP_DIR="$HOME/.local/share/zap"


### PR DESCRIPTION
`ZDOTDIR` is allowing to change directory for `.zshrc` file. It should be set in `/env/zshev` or `~/.zshev`

Reading .zshenv is done automatically only in zsh shell. Not all systems are symlinking /bin/sh -> zsh, some are pointing it to bash (by default) some more exotic ones can point to whatever.

should fix issue zap-zsh/zap#70