### PR TITLE
fix: correct hashbang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/env zsh
+#!/usr/bin/env zsh
 
 main() {
     branch="master"

--- a/zap.zsh
+++ b/zap.zsh
@@ -1,4 +1,4 @@
-#!/bin/env zsh
+#!/usr/bin/env zsh
 # shellcheck disable=SC1090
 
 export ZAP_DIR="$HOME/.local/share/zap"


### PR DESCRIPTION
Set the hashbang to '/usr/bin/env zsh', not '/bin/env zsh', so it works on MacOS aswell as Linux