### PR TITLE
fix: 'permission denied' error when executing: plug 'pabloariasal/zfm'

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -10,7 +10,7 @@ rm -rf "$ZAP_DIR/installed_plugins"
 
 _try_source() {
     sourced=false
-    plugin_files_names=("$1/$2.plugin.zsh"
+    plugin_files_names=("$plugin_dir/$plugin_name.plugin.zsh"
         "$plugin_dir/$plugin_name.zsh"
         "$plugin_dir/$plugin_name.zsh-theme"
         "$plugin_dir/${plugin_name#zsh-}.zsh")
@@ -43,7 +43,7 @@ plug() {
             fi
             echo -e "\e[1A\e[K⚡$plugin_name"
         fi
-        _try_source $plugin_dir $plugin_name
+        _try_source
         if [[ $sourced == false ]]; then
             echo "Failed to source $full_plugin_name"
         fi


### PR DESCRIPTION
When executing `plug 'pabloariasal/zfm'` a `permission denied` error is thrown.

This is caused by the last line of the `zfm.zsh` file:

`"$@"`

via Zap this translates to:

`$HOME/.local/share/zap/plugins/zfm zfm`

This PR fixes the issue caused by the execution of `_try_source` passing 2 arguments, i.e. that would output as shown above.