### PR TITLE
feat: if plug dirname exists then local source only

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -16,7 +16,12 @@ function plug() {
         done
     }
 
-    [[ -f "$1" ]] && source "$1" && return 0
+    # If the directory exists, then local source only
+    if [ -d $(dirname "$1") ]; then
+        [[ -f "$1" ]] && source "$1"
+        return 0
+    fi
+
     local plugin="$1"
     _try_source $plugin && return
     local git_ref="$2"

--- a/zap.zsh
+++ b/zap.zsh
@@ -17,7 +17,7 @@ function plug() {
     }
 
     # If the directory exists, then local source only
-    if [ -d $(dirname "$1") ]; then
+    if [ -d "${1:h}" ]; then
         [[ -f "$1" ]] && source "$1"
         return 0
     fi


### PR DESCRIPTION
When trying to perform a local file and the file does not exist, :zap: Zap will attempt a Git clone and error.

Modified to check to see if the directory containing the local file exists, if so, then treat as a local source only and not move on should the local file not exist.

For example when executing the below
```
plug "$HOME/.zshrc.local"
```

