### PR TITLE
fix: removed useless `_try_source` call

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -23,7 +23,6 @@ function plug() {
     fi
 
     local plugin="$1"
-    _try_source $plugin && return
     local git_ref="$2"
     local plugin_name=${plugin:t}
     local plugin_dir="$ZAP_PLUGIN_DIR/$plugin_name"


### PR DESCRIPTION
It was also called in the wrong way,
probably residue from previous versions