### PR TITLE
feat: search for the plugin file to source (close #118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,7 @@ rm -rf ~/.local/share/zap
 
 ## Notes
 
-Will only work with plugins that are named conventionally, this means that the plugin file is the same name as the repository with the following extensions:
-
-- `.plugin.zsh`
-- `.zsh`
-- `.zsh-theme`
-
-For example: [vim](https://github.com/zap-zsh/vim)
+For sourcing local files use `$HOME` instead of `~` when giving a full path to the file.
 
 <!----------------------------------------------------------------------------->
 

--- a/zap.zsh
+++ b/zap.zsh
@@ -14,7 +14,7 @@ function plug() {
             [[ -e "$plugin_dir/$plugin_name$ext" ]] && source "$plugin_dir/$plugin_name$ext" && return 0
             [[ -e "$plugin_dir/${plugin_name#zsh-}$ext" ]] && source "$plugin_dir/${plugin_name#zsh-}$ext" && return 0
             # If the plugin file has a different name than $plugin_name
-            plugin_filename=$(ls $plugin_dir | grep $ext)
+            plugin_filename=$(command ls $plugin_dir | grep $ext)
             [[ -n $plugin_filename ]] && [[ $(echo $plugin_filename | wc -l) == 1 ]] && source "$plugin_dir/$plugin_filename" && return 0
         done
     }

--- a/zap.zsh
+++ b/zap.zsh
@@ -13,6 +13,9 @@ function plug() {
         for ext in "${extensions[@]}"; do
             [[ -e "$plugin_dir/$plugin_name$ext" ]] && source "$plugin_dir/$plugin_name$ext" && return 0
             [[ -e "$plugin_dir/${plugin_name#zsh-}$ext" ]] && source "$plugin_dir/${plugin_name#zsh-}$ext" && return 0
+            # If the plugin file has a different name than $plugin_name
+            plugin_filename=$(ls $plugin_dir | grep $ext)
+            [[ -n $plugin_filename ]] && [[ $(echo $plugin_filename | wc -l) == 1 ]] && source "$plugin_dir/$plugin_filename" && return 0
         done
     }
 


### PR DESCRIPTION
I made it so zap will look for a file with one of the extensions `.plugin.zsh`, `.zsh-theme` and `.zsh`. If there is only one such file, zap will source it.
I am pretty sure this will cover most cases where the plugin file doesn't have the same name as the repository, because there's usually only one file with the extensions `.plugin.zsh` or `.zsh-theme` in zsh plugin repositories.
Let me know if I missed anything.
P.S. While working on this, I also found out that zap won't recognize `~` as an alias to `$HOME`, so I added it to Notes in the README.