### PR TITLE
feat: add git clone URL prefix variable and update documentation

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.0
       - uses: actions/setup-python@v4.5.0
+        with:
+          python-version: "3.10.11"
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+      - uses: actions/checkout@v3.5.0
+      - uses: actions/setup-python@v4.5.0
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/lovesegfault/beautysh
-    rev: v6.1.0
+    rev: v6.2.1
     hooks:
       - id: beautysh

--- a/README.md
+++ b/README.md
@@ -64,34 +64,40 @@ zsh <(curl -s https://raw.githubusercontent.com/zap-zsh/zap/master/install.zsh) 
 Add the following to your `.zshrc`
 
 ```zsh
-# Example sourcing of files
-plug "$HOME/.config/zsh/aliases.zsh"
-plug "$HOME/.config/zsh/exports.zsh"
-
-# Example install plugins
+# Example install of plugins
 plug "zap-zsh/supercharge"
 plug "zsh-users/zsh-autosuggestions"
 
-#Example plugin pinned to specifc commit or branch, just pass the git reference
+# Example install of a plugin pinned to specifc commit or branch, just pass the git reference
 plug "zsh-users/zsh-syntax-highlighting" "122dc46"
 
-# Example theme
+# Example install of a theme
 plug "zap-zsh/zap-prompt"
 
-# Example install completion
+# Example install of a zsh completion
 plug "esc/conda-zsh-completion"
 ```
 
-You can also use `Zap` to source your custom files, like:
+You can also use `Zap` to install custom plugins or source custom files present on your local filesystem. A file descriptor which points to a directory is treated as a plugin, versus a regular file. For example:
 
 ```zsh
-plug "${ZDOTDIR:-$HOME}/aliases"
+# Example install of a local plugin
+plug "$HOME/plugins/my-custom-prompt"
+
+# Example sourcing of local files
+plug "$HOME/.config/zsh/aliases.zsh"
+plug "$HOME/.config/zsh/exports.zsh"
 ```
 
-:warning:_In this case the file has to be present in your system and the argument passed to `plug` has to be a file descriptor that points to a regular file. This means you actually need to specify the path to the file (absolute or using environment variables like shown above) and, if the file has an extension you must type it._<br>
-For more information about that, take a look at [this issue](https://github.com/zap-zsh/zap/issues/88)
+By default `Zap` when installing a plugin will clone a GitHub repository using a HTTPS web URL, if you require to be able to install from a private GitHub repository you can provide a different URL prefix to be used. For example, using a password-protected SSH key:
 
-Is possible to call `plug` in any interactive shell session to source a file or to download and source a plugin for that particular session.<br>
+```zsh
+# Example git clone using an SSH key
+export ZAP_GITHUB_PREFIX="git@"
+plug "zap-zsh/private-repo"
+```
+
+It is possible to call `plug` in any interactive shell session to source a file or to download and source a plugin for that particular session.<br>
 :warning: If you call `plug` outside your `.zshrc` file, the plugin you sourced will not be sourced at the next shell reload.
 
 ## Commands
@@ -102,6 +108,12 @@ Zap provided commands for updating and cleaning up plugins
 
   ```zsh
   zap update
+  ```
+
+- To list all plugins you are using:
+
+  ```zsh
+  zap list
   ```
 
 - To remove plugins you are no longer using:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ export ZAP_GITHUB_PREFIX="git@"
 plug "zap-zsh/private-repo"
 ```
 
-It is possible to call `plug` in any interactive shell session to source a file or to download and source a plugin for that particular session.<br>
+It is possible to call `plug` in any interactive shell session to source a file or to download and source a plugin for that particular session.
+
 :warning: If you call `plug` outside your `.zshrc` file, the plugin you sourced will not be sourced at the next shell reload.
 
 ## Commands

--- a/zap.zsh
+++ b/zap.zsh
@@ -92,7 +92,7 @@ function _zap_update() {
                 _pull "$ZAP_PLUGIN_DIR/$_plug"
             done ;;
         *)
-: ;;
+            : ;;
     esac
     [[ $ZAP_CLEAN_ON_UPDATE == true ]] && _zap_clean || return 0
 }

--- a/zap.zsh
+++ b/zap.zsh
@@ -40,7 +40,7 @@ function plug() {
     local git_ref="$2"
     if [ ! -d "$plugin_dir" ]; then
         echo "🔌 Zap is installing $plugin_name..."
-        git clone "https://github.com/${plugin}.git" "$plugin_dir" > /dev/null 2>&1 || { echo -e "\e[1A\e[K❌ Failed to clone $plugin_name"; return 12 }
+        git clone "${ZAP_GITHUB_PREFIX:-"https://"}github.com/${plugin}.git" "$plugin_dir" > /dev/null 2>&1 || { echo -e "\e[1A\e[K❌ Failed to clone $plugin_name"; return 12 }
         echo -e "\e[1A\e[K⚡ Zap installed $plugin_name"
     fi
     [[ -n "$git_ref" ]] && { git -C "$plugin_dir" checkout "$git_ref" > /dev/null 2>&1 || { echo "❌ Failed to checkout $git_ref"; return 13 }}
@@ -92,7 +92,7 @@ function _zap_update() {
                 _pull "$ZAP_PLUGIN_DIR/$_plug"
             done ;;
         *)
-            : ;;
+: ;;
     esac
     [[ $ZAP_CLEAN_ON_UPDATE == true ]] && _zap_clean || return 0
 }


### PR DESCRIPTION
- feat: add the ability to change the git clone URL prefix, allowing for SSH keys to be used. 
- feat: update README to be more explicit on how to install local plugins or source local files.
- feat: update README to contain how to use the 'ZAP_GITHUB_PREFIX'.
- feat: update README to contain how to use the 'zap list' command.
- chore: update the github workflow to use the latest versions of the actions.