### PR TITLE
feat: Speed up plugin source file detection

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -9,14 +9,11 @@ fpath+="$ZAP_DIR/completion"
 function plug() {
 
     function _try_source() {
-        typeset -a extensions=(".plugin.zsh" ".zsh-theme" ".zsh")
-        for ext in "${extensions[@]}"; do
-            [[ -e "$plugin_dir/$plugin_name$ext" ]] && source "$plugin_dir/$plugin_name$ext" && return 0
-            [[ -e "$plugin_dir/${plugin_name#zsh-}$ext" ]] && source "$plugin_dir/${plugin_name#zsh-}$ext" && return 0
-            # If the plugin file has a different name than $plugin_name
-            plugin_filename=$(command ls $plugin_dir | grep $ext)
-            [[ -n $plugin_filename ]] && [[ $(echo $plugin_filename | wc -l) -eq 1 ]] && source "$plugin_dir/$plugin_filename" && return 0
-        done
+        local -a initfiles=(
+            $plugin_dir/${plugin_name}.{plugin.,}{z,}sh{-theme,}(N)
+            $plugin_dir/*.{plugin.,}{z,}sh{-theme,}(N)
+        )
+        (( $#initfiles )) && source $initfiles[1]
     }
 
     # If the absolute is a directory then source as a local plugin


### PR DESCRIPTION
The `try_source` function could use some optimization. The current implementation profiles this way:

```zsh
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    2          27.07    13.53   34.68%     27.07    13.53   34.68%  compaudit
 2)    9          32.95     3.66   42.22%     23.51     2.61   30.12%  _try_source
 3)    1          40.43    40.43   51.81%     13.37    13.37   17.13%  compinit
```

Using NULLGLOB pattern matching to populate a list of possible plugin init files and taking the first element of that list both simplifies the function, and also makes it faster.

```zsh
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    2          27.29    13.64   39.04%     27.29    13.64   39.04%  compaudit
 2)    9          24.43     2.71   34.96%     14.20     1.58   20.32%  _new_try_source
 3)    1          40.83    40.83   58.42%     13.54    13.54   19.38%  compinit
```

If you are okay with this kind of advanced pattern matching, this PR also fixes #125 and supreceeds https://github.com/zap-zsh/zap/pull/126.