### PR TITLE
feat: change 'git clone' to be the latest commit only

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -44,7 +44,7 @@ main() {
         rm -rf "$ZAP_DIR"
     }
 
-    git clone -b "${BRANCH:-master}" https://github.com/zap-zsh/zap.git "$ZAP_DIR" > /dev/null 2>&1 || { echo "❌ Failed to install Zap" && return 2 }
+    git clone --depth 1 -b "${BRANCH:-master}" https://github.com/zap-zsh/zap.git "$ZAP_DIR" > /dev/null 2>&1 || { echo "❌ Failed to install Zap" && return 2 }
 
     echo " Zapped"
     echo "Find more plugins at http://zapzsh.org"

--- a/zap.zsh
+++ b/zap.zsh
@@ -37,7 +37,7 @@ function plug() {
     local git_ref="$2"
     if [ ! -d "$plugin_dir" ]; then
         echo "🔌 Zap is installing $plugin_name..."
-        git clone "${ZAP_GITHUB_PREFIX:-"https://"}github.com/${plugin}.git" "$plugin_dir" > /dev/null 2>&1 || { echo -e "\e[1A\e[K❌ Failed to clone $plugin_name"; return 12 }
+        git clone --depth 1 "${ZAP_GITHUB_PREFIX:-"https://"}github.com/${plugin}.git" "$plugin_dir" > /dev/null 2>&1 || { echo -e "\e[1A\e[K❌ Failed to clone $plugin_name"; return 12 }
         echo -e "\e[1A\e[K⚡ Zap installed $plugin_name"
     fi
     [[ -n "$git_ref" ]] && { git -C "$plugin_dir" checkout "$git_ref" > /dev/null 2>&1 || { echo "❌ Failed to checkout $git_ref"; return 13 }}


### PR DESCRIPTION
Modified to perform a `git clone` to be the latest commit only as discussed in Issue #129 

Modified for both installing Zap and installing plugins.

During testing I saw a 35% decrease in the time taken to perform the initial plugin install.