### PR TITLE
fix: resolve two issues with the Zap installation script

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -8,6 +8,19 @@ main() {
     local ZAP_DIR="$HOME/.local/share/zap"
     local ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
 
+    # check if ZAP_DIR already exists
+    [[ -d "$ZAP_DIR" ]] && {
+        echo "Zap is already installed in '$ZAP_DIR'!"
+        read -q "res?Reinstall Zap? [y/N] "
+        echo ""
+        [[ $res == "n" ]] && {
+            echo "❕ skipped!"
+            return
+        }
+        echo "Reinstalling Zap..."
+        rm -rf "$ZAP_DIR"
+    }
+
     # Check if the current .zshrc file exists
     if [ -f "$ZSHRC" ]; then
         # Move the current .zshrc file to the new filename
@@ -31,19 +44,6 @@ main() {
 
     [[ $1 == "--branch" || $1 == "-b" && -n $2 ]] && local BRANCH="$2"
 
-    # check if ZAP_DIR already exists
-    [[ -d "$ZAP_DIR" ]] && {
-        echo "Zap is already installed in '$ZAP_DIR'!"
-        read -q "res?Reinstall Zap? [y/N] "
-        echo ""
-        [[ $res == "n" ]] && {
-            echo "❕ skipped!"
-            return
-        }
-        echo "Reinstalling Zap..."
-        rm -rf "$ZAP_DIR"
-    }
-
     git clone --depth 1 -b "${BRANCH:-master}" https://github.com/zap-zsh/zap.git "$ZAP_DIR" > /dev/null 2>&1 || { echo "❌ Failed to install Zap" && return 2 }
 
     echo " Zapped"
@@ -54,6 +54,6 @@ main() {
 
 main $@
 
-[[ $? -eq 0 ]] && exec zsh || return
+[[ $? -eq 0 ]] && . "$ZSHRC" || return
 
 # vim: ft=zsh ts=4 et

--- a/install.zsh
+++ b/install.zsh
@@ -54,6 +54,6 @@ main() {
 
 main $@
 
-[[ $? -eq 0 ]] && . "$ZSHRC" || return
+[[ $? -eq 0 ]] && source "$ZSHRC" || return
 
 # vim: ft=zsh ts=4 et


### PR DESCRIPTION
Resolve the following two issues with the Zap installation script

1. Move the check to see if Zap is already installed to before any changes to the .zshrc file are made.

2. Change the launch of a new zsh session to rather reread the .zshrc file to maintain variables, history and allow the install script to be launched from an automation script.  This resolves issue #132 