### PR TITLE
fix: keep the existing '.zshrc' file in the same directory

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -24,7 +24,7 @@ main() {
     # Check if the current .zshrc file exists
     if [ -f "$ZSHRC" ]; then
         # Move the current .zshrc file to the new filename
-        mv "$ZSHRC" "$HOME/$NEW_ZSHRC"
+        mv "$ZSHRC" "${ZSHRC:A:h}/$NEW_ZSHRC"
         echo "Moved .zshrc to $NEW_ZSHRC"
     else
         echo "No .zshrc file found, creating a new one..."


### PR DESCRIPTION
The current version moves the existing `.zshrc` file to the $HOME directory even when the $ZDOTDIR is populated.

This fix will keep the existing `.zshrc` file in the same location as specified by the $ZDOTDIR