### PR TITLE
feat: cleanup and fix version output

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -129,8 +129,10 @@ COMMANDS:
 
 function _zap_version() {
     local -Ar color=(BLUE "\033[1;34m" GREEN "\033[1;32m" RESET "\033[0m")
-    local _ver=${$(git -C $ZAP_DIR describe --tags HEAD)%%-*} _branch=$(git -C "$ZAP_DIR" branch --show-current) _commit=${$(git -C $ZAP_DIR describe --tags HEAD)##*-}
-    echo "⚡ Zap v${color[GREEN]}${_ver}${color[RESET]}\nBranch:\t${color[GREEN]}${_branch}${color[RESET]}\nCommit:\t${color[BLUE]}${_commit#g}${color[RESET]}"
+    local _branch=$(git -C "$ZAP_DIR" branch --show-current)
+    local _hash=$(git -C "$ZAP_DIR" log -1 --pretty="%h")
+    local _date=$(git -C "$ZAP_DIR" log -1 --pretty="%cs")
+    echo "⚡ Zap - Version\n\nBranch: ${color[GREEN]}${_branch}${color[RESET]}\nCommit Hash: ${color[BLUE]}${_hash#g}${color[RESET]}\nCommit Date: ${color[BLUE]}${_date#g}${color[RESET]}"
 }
 
 function zap() {


### PR DESCRIPTION
Executing `zap version` failed due to repository clone with a depth=1 causes the tag to not be visible.

![image](https://user-images.githubusercontent.com/33818/235968377-122bf38d-ddf2-43a9-abaf-48b1d1c2b87d.png)

The output after this commit no longer fails and now also outputs the commit date

![image](https://user-images.githubusercontent.com/33818/235968676-9c3f347a-f383-4f28-8ef0-1352132d3d8f.png)
