### PR TITLE
fix: ZSHRC variable no longer in scope

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -52,6 +52,6 @@ main() {
 
 main $@
 
-[[ $? -eq 0 ]] && source "$ZSHRC" || return
+[[ $? -eq 0 ]] && source "${ZDOTDIR:-$HOME}/.zshrc" || return
 
 # vim: ft=zsh ts=4 et


### PR DESCRIPTION
Dont use ZSHRC variable outside the main() function as no longer in scope.

As reported in issue #134 