### PR TITLE
fix: solve 2 issues #73 and #141

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ plug "$HOME/.config/zsh/aliases.zsh"
 plug "$HOME/.config/zsh/exports.zsh"
 ```
 
-By default `Zap` when installing a plugin will clone a GitHub repository using a HTTPS web URL, if you require to be able to install from a private GitHub or from a different git server repository (for example GitLab) you can provide a different URL prefix to be used. For example, using a password-protected SSH key:
+By default `Zap` when installing a plugin will clone a GitHub repository using a HTTPS web URL, if you require to be able to install from a private GitHub or from a different git server (for example GitLab) you can provide a different URL prefix to be used. For example, using a password-protected SSH key:
 
 ```zsh
 # Your ZSHRC file

--- a/README.md
+++ b/README.md
@@ -83,12 +83,20 @@ plug "$HOME/.config/zsh/aliases.zsh"
 plug "$HOME/.config/zsh/exports.zsh"
 ```
 
-By default `Zap` when installing a plugin will clone a GitHub repository using a HTTPS web URL, if you require to be able to install from a private GitHub repository you can provide a different URL prefix to be used. For example, using a password-protected SSH key:
+By default `Zap` when installing a plugin will clone a GitHub repository using a HTTPS web URL, if you require to be able to install from a private GitHub or from a different git server repository (for example GitLab) you can provide a different URL prefix to be used. For example, using a password-protected SSH key:
 
 ```zsh
-# Example git clone using an SSH key
-export ZAP_GITHUB_PREFIX="git@"
+# Your ZSHRC file
+...
+
+# Example globally set Zap to git clone using an SSH key
+export ZAP_GIT_PREFIX='git@github.com:'
 plug "zap-zsh/private-repo"
+
+# Example git clone using GitLab for a single plugin
+ZAP_GIT_PREFIX='https://gitlab.com/' plug "user/repo"
+
+...
 ```
 
 It is possible to call `plug` in any interactive shell session to source a file or to download and source a plugin for that particular session.

--- a/zap.zsh
+++ b/zap.zsh
@@ -37,7 +37,7 @@ function plug() {
     local git_ref="$2"
     if [ ! -d "$plugin_dir" ]; then
         echo "🔌 Zap is installing $plugin_name..."
-        git clone --depth 1 "${ZAP_GITHUB_PREFIX:-"https://"}github.com/${plugin}.git" "$plugin_dir" > /dev/null 2>&1 || { echo -e "\e[1A\e[K❌ Failed to clone $plugin_name"; return 12 }
+        git clone --depth 1 "${ZAP_GIT_PREFIX:-"https://github.com/"}${plugin}.git" "$plugin_dir" > /dev/null 2>&1 || { echo -e "\e[1A\e[K❌ Failed to clone $plugin_name"; return 12 }
         echo -e "\e[1A\e[K⚡ Zap installed $plugin_name"
     fi
     [[ -n "$git_ref" ]] && { git -C "$plugin_dir" checkout "$git_ref" > /dev/null 2>&1 || { echo "❌ Failed to checkout $git_ref"; return 13 }}


### PR DESCRIPTION
* fix the behavior og ZAP_GITHUB_PREFIX that does not work due to different URL syntax between ssh and http URLs ( fixes #141 )
* allow other git servers besides github and resolves #73
The user have to use `ZAP_GIT_PREFIX` like so:
```zsh
ZAP_GIT_PREFIX='git@gitlab.com:'
```
or
```zsh
ZAP_GIT_PREFIX='git@github.com:'
```

If this variable is not set it defaults to `https://github.com/`.
:warning: please note the trailing `/` or `:`