### PR TITLE
feat: use XDG standard path in $ZAP_DIR

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -3,7 +3,7 @@
 main() {
 
     local BACKUP_SUFFIX="$(date +%Y-%m-%d)_$(date +%s)"
-    local ZAP_DIR="$HOME/.local/share/zap"
+    local ZAP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/zap"
     local ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
 
     # check if ZAP_DIR already exists
@@ -34,7 +34,7 @@ main() {
     fi
 
     echo "# Created by Zap installer" >> "$ZSHRC"
-    echo '[ -f "$HOME/.local/share/zap/zap.zsh" ] && source "$HOME/.local/share/zap/zap.zsh"' >> "$ZSHRC"
+    echo '[ -f "${XDG_DATA_HOME:-$HOME/.local/share}/zap/zap.zsh" ] && source "${XDG_DATA_HOME:-$HOME/.local/share}/zap/zap.zsh"' >> "$ZSHRC"
     echo 'plug "zsh-users/zsh-autosuggestions"' >> "$ZSHRC"
     echo 'plug "zap-zsh/supercharge"' >> "$ZSHRC"
     echo 'plug "zap-zsh/zap-prompt"' >> "$ZSHRC"

--- a/install.zsh
+++ b/install.zsh
@@ -26,10 +26,6 @@ main() {
         echo "Moved .zshrc to .zshrc_$BACKUP_SUFFIX"
     else
         echo "No .zshrc file found, creating a new one..."
-    fi
-
-    # Check if .zshrc file exists, create it if not
-    if [ ! -f "$ZSHRC" ]; then
         touch "$ZSHRC"
     fi
 

--- a/zap.zsh
+++ b/zap.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 export ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
-export ZAP_DIR="$HOME/.local/share/zap"
+export ZAP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/zap"
 export ZAP_PLUGIN_DIR="$ZAP_DIR/plugins"
 export -a ZAP_INSTALLED_PLUGINS=()
 fpath+="$ZAP_DIR/completion"


### PR DESCRIPTION
In this PR I changed the `$ZAP_DIR`'s value to the [XDG's standard](https://wiki.archlinux.org/title/XDG_Base_Directory#User_directories) so the zap binary will be installed and used from there.

Warning: this could break the system for people who have a set `$XDG_DATA_HOME` to a non-default value forcing them to move their files/reinstall