### PR TITLE
feat: add -k, --keep flags to keep existing .zshrc files

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -21,7 +21,7 @@ main() {
         {h,-help}=HELP \
         {k,-keep}=KEEP \
         {b,-branch}:=BRANCH ||
-        return 1
+    return 1
  
     [[ -z "$HELP" ]] || { print -l $OPTIONS_USAGE && return }
 

--- a/install.zsh
+++ b/install.zsh
@@ -22,7 +22,7 @@ main() {
         {k,-keep}=KEEP \
         {b,-branch}:=BRANCH ||
     return 1
- 
+
     [[ -z "$HELP" ]] || { print -l $OPTIONS_USAGE && return }
 
     local BACKUP_SUFFIX="$(date +%Y-%m-%d)_$(date +%s)"

--- a/install.zsh
+++ b/install.zsh
@@ -43,7 +43,7 @@ main() {
     }
 
     # Clone the Zap Repository branch
-    git clone -b "$BRANCH" https://github.com/zap-zsh/zap.git "$ZAP_DIR" > /dev/null 2>&1 || { echo "❌ Failed to install Zap" && return 2 }
+    git clone -b "$BRANCH" https://github.com/zap-zsh/zap.git "$ZAP_DIR" &> /dev/null || { echo "❌ Failed to install Zap" && return 2 }
 
     # Only modify .zshrc file if --keep flag not set
     if [[ -z "$KEEP" ]]; then

--- a/install.zsh
+++ b/install.zsh
@@ -2,6 +2,29 @@
 
 main() {
 
+    local HELP KEEP
+    local BRANCH=(master)
+    local OPTIONS_USAGE=(
+        "USAGE:"
+        "    install.zsh [options]"
+        " "
+        "OPTIONS:"
+        "    -h, --help     Show this help message"
+        "    -k, --keep     Don't override existing .zshrc"
+        "    -b, --branch   Zap repository branch name"
+    )
+
+    echo "⚡ Zap - Installer\n"
+
+    zmodload zsh/zutil
+    zparseopts -D -F -K -- \
+        {h,-help}=HELP \
+        {k,-keep}=KEEP \
+        {b,-branch}:=BRANCH ||
+        return 1
+ 
+    [[ -z "$HELP" ]] || { print -l $OPTIONS_USAGE && return }
+
     local BACKUP_SUFFIX="$(date +%Y-%m-%d)_$(date +%s)"
     local ZAP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/zap"
     local ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
@@ -19,29 +42,30 @@ main() {
         rm -rf "$ZAP_DIR"
     }
 
-    # Get the branch of the Zap ZSH repository to clone
-    [[ $1 == "--branch" || $1 == "-b" && -n $2 ]] && local BRANCH="$2"
+    # Clone the Zap Repository branch
+    git clone -b "$BRANCH" https://github.com/zap-zsh/zap.git "$ZAP_DIR" > /dev/null 2>&1 || { echo "❌ Failed to install Zap" && return 2 }
 
-    git clone -b "${BRANCH:-master}" https://github.com/zap-zsh/zap.git "$ZAP_DIR" > /dev/null 2>&1 || { echo "❌ Failed to install Zap" && return 2 }
+    # Only modify .zshrc file if --keep flag not set
+    if [[ -z "$KEEP" ]]; then
+        # Check the .zshrc template exists
+        if [ ! -f "$ZAP_DIR/templates/default-zshrc" ]; then
+            echo "Template .zshrc file was not found in Zap installation"
+            return 2
+        fi
 
-    # Check the .zshrc template exists
-    if [ ! -f "$ZAP_DIR/templates/default-zshrc" ]; then
-        echo "Template .zshrc file was not found in Zap installation"
-        return 2
+        # Check if the current .zshrc file exists
+        if [ -f "$ZSHRC" ]; then
+            # Move the current .zshrc file to the new filename
+            mv "$ZSHRC" "${ZSHRC}_${BACKUP_SUFFIX}"
+            echo "Moved .zshrc to .zshrc_$BACKUP_SUFFIX"
+        else
+            echo "No .zshrc file found, creating a new one..."
+            touch "$ZSHRC"
+        fi
+
+        # Write out the .zshrc template to the .zshrc
+        cat "$ZAP_DIR/templates/default-zshrc" >> "$ZSHRC"
     fi
-
-    # Check if the current .zshrc file exists
-    if [ -f "$ZSHRC" ]; then
-        # Move the current .zshrc file to the new filename
-        mv "$ZSHRC" "${ZSHRC}_${BACKUP_SUFFIX}"
-        echo "Moved .zshrc to .zshrc_$BACKUP_SUFFIX"
-    else
-        echo "No .zshrc file found, creating a new one..."
-        touch "$ZSHRC"
-    fi
-
-    # Write out the .zshrc template to the .zshrc
-    cat "$ZAP_DIR/templates/default-zshrc" >> "$ZSHRC"
 
     echo " Zapped"
     echo "Find more plugins at http://zapzsh.org"


### PR DESCRIPTION
- feat: add -k, --keep flags to keep existing .zshrc files   ( resolves #154  and  #148 )
- feat: enhance the argument parsing
- feat: add -h, --help flags to display help message

```
⚡ Zap - Installer

USAGE:
    install.zsh [options]
 
OPTIONS:
    -h, --help     Show this help message
    -k, --keep     Don't override existing .zshrc
    -b, --branch   Zap repository branch name
```