### PR TITLE
feat: minimise relative directory plug as local versus performing a git clone

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -17,7 +17,9 @@ function plug() {
     }
 
     # If the absolute is a directory then source as a local plugin
+    pushd -q "$ZAP_DIR"
     local plugin_absolute="${1:A}"
+    popd -q
     if [ -d "${plugin_absolute}" ]; then
         local plugin="${plugin_absolute}"
         local plugin_name="${plugin:t}"


### PR DESCRIPTION
As discussed in Issue #159 

This provides a quick fix to minimise relative directory plug being recognised as local versus performing the expected git clone.