### PR TITLE
fix: `apt install lsd` command in test-suite.yml

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -46,6 +46,6 @@ jobs:
           # Test Environment Variable
           [[ -d "$ZAP_DIR" ]]
           # Test Plugin Installation
-          apt install lsd # needed for next steps
+          sudo apt install lsd # needed for next steps
           plug "wintermi/zsh-lsd"
           git -C "${ZAP_DIR}/plugins/zsh-lsd/" status || exit 1


### PR DESCRIPTION
This should fix the:
```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
```