### PR TITLE
fix: install.sh: support ZSH(<5.8)

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -17,7 +17,7 @@ main() {
     echo "⚡ Zap - Installer\n"
 
     zmodload zsh/zutil
-    zparseopts -D -F -K -- \
+    zparseopts -D -K -- \
         {h,-help}=HELP \
         {k,-keep}=KEEP \
         {b,-branch}:=BRANCH ||


### PR DESCRIPTION
Support versions of ZSH < 5.8

#169 