### PR TITLE
feat: support glob pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ plug "$HOME/plugins/my-custom-prompt"
 # Example sourcing of local files
 plug "$HOME/.config/zsh/aliases.zsh"
 plug "$HOME/.config/zsh/exports.zsh"
+
+# Example install all local plugin in folder (must match pattern *.{plugin.,}{z,}sh{-theme,})
+plug "$HOME/plugins/*"
 ```
 
 By default `Zap` when installing a plugin will clone a GitHub repository using a HTTPS web URL, if you require to be able to install from a private GitHub or from a different git server (for example GitLab) you can provide a different URL prefix to be used. For example:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ plug "$HOME/plugins/my-custom-prompt"
 plug "$HOME/.config/zsh/aliases.zsh"
 plug "$HOME/.config/zsh/exports.zsh"
 
-# Example install all local plugin in folder (must match pattern *.{plugin.,}{z,}sh{-theme,})
+# Example install all local plugin in a folder (must be an absolute path anding with *)
 plug "$HOME/plugins/*"
 ```
 

--- a/zap.zsh
+++ b/zap.zsh
@@ -4,6 +4,7 @@ export ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
 export ZAP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/zap"
 export ZAP_PLUGIN_DIR="$ZAP_DIR/plugins"
 export -a ZAP_INSTALLED_PLUGINS=()
+fpath+="$ZAP_DIR/completion"
 
 function plug() {
 
@@ -20,6 +21,7 @@ function plug() {
             # Use the specified plugin_name
             local -a initfiles=(
                 $plugin_dir/${plugin_name}.{plugin.,}{z,}sh{-theme,}(N)
+                $plugin_dir/*.{plugin.,}{z,}sh{-theme,}(N)
             )
             (( $#initfiles )) && source $initfiles[1]
         fi

--- a/zap.zsh
+++ b/zap.zsh
@@ -4,16 +4,25 @@ export ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
 export ZAP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/zap"
 export ZAP_PLUGIN_DIR="$ZAP_DIR/plugins"
 export -a ZAP_INSTALLED_PLUGINS=()
-fpath+="$ZAP_DIR/completion"
 
 function plug() {
 
     function _try_source() {
-        local -a initfiles=(
-            $plugin_dir/${plugin_name}.{plugin.,}{z,}sh{-theme,}(N)
-            $plugin_dir/*.{plugin.,}{z,}sh{-theme,}(N)
-        )
-        (( $#initfiles )) && source $initfiles[1]
+        if [[ "$plugin_name" == "*" ]]; then
+            # Treat * as a glob pattern
+            local -a initfiles=(
+                $plugin_dir/*.{plugin.,}{z,}sh{-theme,}(N)
+            )
+            for file in "${initfiles[@]}"; do
+                [[ -f "$file" ]] && source "$file"
+            done
+        else
+            # Use the specified plugin_name
+            local -a initfiles=(
+                $plugin_dir/${plugin_name}.{plugin.,}{z,}sh{-theme,}(N)
+            )
+            (( $#initfiles )) && source $initfiles[1]
+        fi
     }
 
     # If the absolute is a directory then source as a local plugin
@@ -24,6 +33,9 @@ function plug() {
         local plugin="${plugin_absolute}"
         local plugin_name="${plugin:t}"
         local plugin_dir="${plugin_absolute}"
+    elif [ "${plugin_absolute:t}" = "*" ]; then
+        local plugin_name="${plugin_absolute:t}"
+        local plugin_dir="${plugin_absolute:h}"
     else
         # If the basename directory exists, then local source only
         if [ -d "${plugin_absolute:h}" ]; then


### PR DESCRIPTION
- Add support for adding all files in a folder if "/*" is included in the given path. For example:

```zsh
plug "$HOME/plugins/*"
```

- For the original functionality I have removed the glob pattern matching there because it is currently not being used since we are only sourcing the 1st element return of `initfiles` array. Instead of creating a loop and be done with it, I decided to look for specific "*" included in the path then do a loop otherwise I just source the 1st element, keeping the original function intact