### PR TITLE
fix: correct the method used to obtain the version tag to focus on the current branch not across all branches

### DIFF
--- a/zap.zsh
+++ b/zap.zsh
@@ -153,7 +153,7 @@ OPTIONS:
 function _zap_version() {
     local -Ar color=(BLUE "\033[0;34m" GREEN "\033[0;32m" RESET "\033[0m")
     local _branch=$(git -C "$ZAP_DIR" branch --show-current)
-    local _version=$(git -C "$ZAP_DIR" describe --tags `git -C "$ZAP_DIR" rev-list --tags --max-count=1`)
+    local _version=$(git -C "$ZAP_DIR" describe --abbrev=0 --tags)
     local _commit=$(git -C "$ZAP_DIR" log -1 --pretty="%h (%cr)")
     echo "⚡ Zap - Version\n\nVersion: ${color[GREEN]}${_branch}/${_version}${color[RESET]}\nCommit Hash: ${color[BLUE]}${_commit}${color[RESET]}"
 }


### PR DESCRIPTION
fix: correct the method used to obtain the version tag to focus on the current branch not across all branches

Below screenshot of `zap version` showing the new version number when it should be showing the installed version `1.2.1` 

Before and After `git` commands to correct the version number.

![winterlabs 2024-04-09 at 20 39 54@2x](https://github.com/zap-zsh/zap/assets/33818/29fc118a-a191-4f52-b161-dabd5bc1d84c)
